### PR TITLE
Might as well have a proper "ready" system

### DIFF
--- a/templates/default/messloader.js
+++ b/templates/default/messloader.js
@@ -1,3 +1,30 @@
+var JSMESS = JSMESS || {};
+JSMESS._readySet = false;
+JSMESS._readyList = [];
+JSMESS._runReadies = function() {
+	if (JSMESS._readyList) {
+		for (var r=0; r < JSMESS._readyList.length; r++) {
+			JSMESS._readyList[r].call(window, []);
+		};
+		JSMESS._readyList = [];
+	};
+};
+JSMESS._readyCheck = function() {
+	if (JSMESS.running) {
+		JSMESS._runReadies();
+	} else {
+		JSMESS._readySet = setTimeout(JSMESS._readyCheck, 10);
+	};
+};
+JSMESS.ready = function(r) {
+	if (JSMESS.running) {
+		r.call(window, []);
+	} else {
+		JSMESS._readyList.push(function() { return r.call(window, []); } );
+		if (!(JSMESS._readySet)) JSMESS._readyCheck();
+	};
+};
+
 var gamename = 'GAME_FILE';
 var game_file = null;
 var bios_filenames = 'BIOS_FILES'.split(' ');

--- a/templates/default/pre.js
+++ b/templates/default/pre.js
@@ -1,7 +1,7 @@
 if(!window.console){ window.console = {log: function(){} }; }
 var JSMESS = JSMESS || {};
 JSMESS.running = false;
-JSMESS.notifyMainLoop = function() { console.log("JSMESS is now running"); }
+JSMESS.ready(function() { console.log("JSMESS is now running"); });
 JSMESS.MESS_BUILD_VERSION = "JSMESS_MESS_BUILD_VERSION";
 JSMESS.EMCC_VERSION = "JSMESS_EMCC_VERSION";
 JSMESS.EMCC_FLAGS = "JSMESS_EMCC_FLAGS";


### PR DESCRIPTION
This + https://gist.github.com/vitorio/8749336 = in-page notification when JSMESS is booted.

Add new functions after messloader.js defines JSMESS.ready() like you would with jQuery:

JSMESS.ready(function() { //your code here });
